### PR TITLE
Add a chutney "wait_until_bootstrap" command

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -37,6 +37,22 @@ torrc_option_warn_count =  0
 # Get verbose tracebacks, so we can diagnose better.
 cgitb.enable(format="plain")
 
+def getenv_int(envvar, default):
+    """
+       Return the value of the environment variable 'envar' as an integer,
+       or 'default' if no such variable exists.
+
+       Raise ValueError if the environment variable is set, but not to
+       an integer.
+    """
+    # TODO: Use this function in more places.
+    strval = os.environ.get(envvar)
+    if strval is None:
+        return default
+    try:
+        return int(strval)
+    except ValueError:
+        raise ValueError("Invalid value for environment variable %s: expected an integer, but got %r"%(envvar,strval))
 
 def mkdir_p(d, mode=448):
     """Create directory 'd' and all of its parents as needed.  Unlike
@@ -1151,7 +1167,7 @@ class Network(object):
 
     def wait_for_bootstrap(self):
         print("Waiting for nodes to bootstrap...")
-        limit = 20 #bootstrap time
+        limit = getenv_int("CHUTNEY_START_TIME", 20)
         delay = 0.5
         controllers = [n.getController() for n in self._nodes]
         elapsed = 0.0

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -797,7 +797,7 @@ class LocalNodeController(NodeController):
         return os.path.join(datadir, logname)
 
     def getLastBootstrapStatus(self):
-        """Look through the logs and return the last bootstrapp message
+        """Look through the logs and return the last bootstrap message
            received as a 3-tuple of percentage complete, keyword
            (optional), and message.
         """


### PR DESCRIPTION
It waits for up to 20 seconds, checking whether the logged
bootstrapped status for every node is 100%.  If it is, great: it
succeeds.  If not, it dumps the bootstrap statuses and exits.