### PR TITLE
test-network: Try a default start time of 120 seconds

### DIFF
--- a/tools/test-network-impl.sh
+++ b/tools/test-network-impl.sh
@@ -11,9 +11,11 @@ fi
 # chutney starts verifying after CHUTNEY_START_TIME seconds,
 # keeps on trying for CHUTNEY_BOOTSTRAP_TIME seconds,
 # and then stops after CHUTNEY_STOP_TIME seconds.
-# Even the fastest chutney networks take 5-10 seconds for their first consensus
-# and then 10 seconds after that for relays to bootstrap and upload descriptors
-# But chutney defaults to running a bit more slowly, so it is more reliable.
+# Even the fastest chutney networks take 5-10 seconds for their first consensus,
+# and then 10 seconds after that for relays to bootstrap and upload descriptors,
+# and then 10 seconds after that for clients and onion services to bootstrap.
+# But chutney defaults to running a bit more slowly, so it is more reliable,
+# and we allow a bit more time, in case the machine is heavily loaded.
 export CHUTNEY_START_TIME=${CHUTNEY_START_TIME:-120}
 export CHUTNEY_BOOTSTRAP_TIME=${CHUTNEY_BOOTSTRAP_TIME:-60}
 export CHUTNEY_STOP_TIME=${CHUTNEY_STOP_TIME:-0}

--- a/tools/test-network-impl.sh
+++ b/tools/test-network-impl.sh
@@ -14,7 +14,7 @@ fi
 # Even the fastest chutney networks take 5-10 seconds for their first consensus
 # and then 10 seconds after that for relays to bootstrap and upload descriptors
 # But chutney defaults to running a bit more slowly, so it is more reliable.
-export CHUTNEY_START_TIME=${CHUTNEY_START_TIME:-60}
+export CHUTNEY_START_TIME=${CHUTNEY_START_TIME:-120}
 export CHUTNEY_BOOTSTRAP_TIME=${CHUTNEY_BOOTSTRAP_TIME:-60}
 export CHUTNEY_STOP_TIME=${CHUTNEY_STOP_TIME:-0}
 


### PR DESCRIPTION
For Travis and other slow or loaded machines.

TODO: update the README with the new default.
(Conflicts with 30059.)

Bugfix for 30064.