### PR TITLE
make chutney work on FreeBSD

### DIFF
--- a/chutney
+++ b/chutney
@@ -12,7 +12,13 @@ then
     export CHUTNEY_PATH
 fi
 
-binaries="python python3 python2"
+if [ "$(uname)" == "FreeBSD" ]
+then
+    binaries="python3.6 python2.7"
+  else
+    binaries="python python3 python2"
+fi
+
 
 if ! test "${PYTHON+y}"
 then


### PR DESCRIPTION
  - FreeBSD 13.0-CURRENT amd64 1300048 1300048;
  - python36-3.6.9;
  - Tor 0.4.2.2-alpha (git-e5b8bd38abae3ef0)
  - OpenSSL 1.1.1d-freebsd.

`tor`'s source code (e5b8bd3) and `chutney`'s af72126 worked fine on **FreeBSD**.


```
$ ls
chutney tor
$ cd tor && make && make test-network
  ...
$CHUTNEY_PATH was not set.
Assuming test-network.sh will find ./../chutney
test-network.sh: $TOR_DIR not set, trying $PWD
test-network.sh: $CHUTNEY_PATH not valid, trying $TOR_DIR/../chutney
test-network.sh: Calling newer chutney script $PWD/../chutney/tools/test-network.sh
test-network.sh: using CHUTNEY_DNS_CONF '/dev/null'
test-network.sh: $TOR_DIR not set, trying $PWD
test-network.sh: $TOR_DIR is a Tor 0.3.5 or later build directory
test-network.sh: $CHUTNEY_PATH not valid, trying $TOR_DIR/../chutney
test-network.sh: Setting $CHUTNEY_TOR and $CHUTNEY_TOR_GENCERT based on TOR_DIR: '$PWD'
test-network.sh: Using $CHUTNEY_TOR: '$PWD/src/app/tor' and $CHUTNEY_TOR_GENCERT: '$PWD/src/tools/tor-gencert'
==== Running tests: attempt 1/1

Launching chutney using Python 3.6.9

    ...

==== Chutney succeeded after 1 attempt(s).
```