### PR TITLE
Travis: Run pypy with Tor 0.4.2 on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,8 @@ matrix:
 
     ## PyPy versions
     ## PyPy isn't packaged for Travis Bionic yet
+    ## Tor master doesn't work on Travis Xenial, because it only has
+    ## OpenSSL 1.1.0
 
     ## Pypy 2
     ## End of Life: "forever"
@@ -184,11 +186,12 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb https://deb.torproject.org/torproject.org tor-nightly-master-xenial main'
+            - sourceline: 'deb https://deb.torproject.org/torproject.org tor-nightly-0.4.2.x-xenial main'
               key_url: 'https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc'
           packages:
             - shellcheck
             - tor
+      env: TOR="0.4.2-nightly" NETWORK_FLAVOUR="basic-min"
 
     ## PyPy does not have documented end of life dates
     - python: "pypy3"
@@ -196,11 +199,12 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb https://deb.torproject.org/torproject.org tor-nightly-master-xenial main'
+            - sourceline: 'deb https://deb.torproject.org/torproject.org tor-nightly-0.4.2.x-xenial main'
               key_url: 'https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc'
           packages:
             - shellcheck
             - tor
+      env: TOR="0.4.2-nightly" NETWORK_FLAVOUR="basic-min"
 
   ## Uncomment to allow the build to report success (with non-required
   ## sub-builds continuing to run) if all required sub-builds have


### PR DESCRIPTION
* PyPy isn't packaged for Travis Bionic yet
* Tor master doesn't work on Travis Xenial, because it only has
  OpenSSL 1.1.0, and Tor master requires OpenSSL 1.1.1

Closes ticket 32820.