### PR TITLE
Remove temporary files created in 'show_warnings()'

### DIFF
--- a/tools/warnings.sh
+++ b/tools/warnings.sh
@@ -77,6 +77,8 @@ show_warnings() {
     if [ "$CHUTNEY_WARNINGS_SUMMARY" != true ]; then
         $ECHO_Q ""
     fi
+    # Remove the temporary files we created
+    rm "${LOGS}" "${FILTERED_LOGS}"
 }
 
 usage() {


### PR DESCRIPTION
See [ticket #32972](https://trac.torproject.org/projects/tor/ticket/32972).

> When the Chutney test-network script ends, it displays warnings from the tor logs. It summarizes/filters them in the show_warnings() function in tools/warnings.sh. This function creates two files with LOGS=$(mktemp) and FILTERED_LOGS=$(mktemp) but never deletes them when it's done.