### PR TITLE
Updated usage comments in 'bootstrap-network.sh'

### DIFF
--- a/tools/bootstrap-network.sh
+++ b/tools/bootstrap-network.sh
@@ -10,7 +10,7 @@
 # Usage:
 #    tools/bootstrap-network.sh [network-flavour]
 #    network-flavour: one of the files in the networks directory,
-#                     (default: 'basic')
+#                     (default: 'bridges+hs-v2')
 #
 
 # Get a working chutney path


### PR DESCRIPTION
See [ticket #33023](https://trac.torproject.org/projects/tor/ticket/33023).

>  The usage comment says the following:
>
>```
># Usage:
>#    tools/bootstrap-network.sh [network-flavour]
>#    network-flavour: one of the files in the networks directory,
>#                     (default: 'basic')
>```
> 
>but the actual code says the following:
>
>```
># Set the variables for the chutney network flavour
>export NETWORK_FLAVOUR=${NETWORK_FLAVOUR:-"bridges+hs-v2"}
>[ -n "$1" ] && { NETWORK_FLAVOUR=$1; shift; }
>export CHUTNEY_NETWORK="$CHUTNEY_PATH/networks/$NETWORK_FLAVOUR"
>```
>
>As you can see, the comments say that the default network is 'basic', but the code actually starts 'bridges+hs-v2'.