### PR TITLE
Support non-existing absolute paths for the data directory

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -131,9 +131,13 @@ def get_absolute_chutney_path():
     return os.path.abspath(relative_chutney_path)
 
 def get_absolute_net_path():
+    data_dir = os.environ.get('CHUTNEY_DATA_DIR', 'net')
+    if os.path.isabs(data_dir):
+        # if we are given an absolute path, we should use it
+        return data_dir
     # use the chutney path as the default
     absolute_chutney_path = get_absolute_chutney_path()
-    relative_net_path = os.environ.get('CHUTNEY_DATA_DIR', 'net')
+    relative_net_path = data_dir
     # but what is it relative to?
     # let's check if it's in CHUTNEY_PATH first, to preserve
     # backwards-compatible behaviour

--- a/tools/bootstrap-network.sh
+++ b/tools/bootstrap-network.sh
@@ -26,14 +26,23 @@ if [ -d "$PWD/$CHUTNEY_PATH" ] && [ -x "$PWD/$CHUTNEY_PATH/chutney" ]; then
 fi
 
 # Get a working net path
-if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
-    # looks like a broken path: use the chutney path as a base
-    export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
-fi
-if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
-    # looks like a relative path: make chutney path absolute
-    export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
-fi
+case "$CHUTNEY_DATA_DIR" in
+  /*)
+    # if an absolute path, then leave as-is
+    # chutney will make this directory automatically if needed
+    ;;
+  *)
+    # if a relative path
+    if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
+        # looks like a broken path: use the chutney path as a base
+        export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
+    fi
+    if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
+        # looks like a relative path: make chutney path absolute
+        export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
+    fi
+    ;;
+esac
 
 CHUTNEY="$CHUTNEY_PATH/chutney"
 myname=$(basename "$0")

--- a/tools/hsaddress.sh
+++ b/tools/hsaddress.sh
@@ -19,14 +19,23 @@ if [ -d "$PWD/$CHUTNEY_PATH" ] && [ -x "$PWD/$CHUTNEY_PATH/chutney" ]; then
 fi
 
 # Get a working net path
-if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
-    # looks like a broken path: use the chutney path as a base
-    export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
-fi
-if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
-    # looks like a relative path: make chutney path absolute
-    export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
-fi
+case "$CHUTNEY_DATA_DIR" in
+  /*)
+    # if an absolute path, then leave as-is
+    # chutney will make this directory automatically if needed
+    ;;
+  *)
+    # if a relative path
+    if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
+        # looks like a broken path: use the chutney path as a base
+        export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
+    fi
+    if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
+        # looks like a relative path: make chutney path absolute
+        export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
+    fi
+    ;;
+esac
 
 NAME=$(basename "$0")
 DEST="$CHUTNEY_DATA_DIR/nodes"

--- a/tools/warnings.sh
+++ b/tools/warnings.sh
@@ -23,14 +23,23 @@ if [ -d "$PWD/$CHUTNEY_PATH" ] && [ -x "$PWD/$CHUTNEY_PATH/chutney" ]; then
 fi
 
 # Get a working net path
-if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
-    # looks like a broken path: use the chutney path as a base
-    export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
-fi
-if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
-    # looks like a relative path: make chutney path absolute
-    export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
-fi
+case "$CHUTNEY_DATA_DIR" in
+  /*)
+    # if an absolute path, then leave as-is
+    # chutney will make this directory automatically if needed
+    ;;
+  *)
+    # if a relative path
+    if [ ! -d "$CHUTNEY_DATA_DIR" ]; then
+        # looks like a broken path: use the chutney path as a base
+        export CHUTNEY_DATA_DIR="$CHUTNEY_PATH/net"
+    fi
+    if [ -d "$PWD/$CHUTNEY_DATA_DIR" ]; then
+        # looks like a relative path: make chutney path absolute
+        export CHUTNEY_DATA_DIR="$PWD/$CHUTNEY_DATA_DIR"
+    fi
+    ;;
+esac
 
 show_warnings() {
     # Work out the file and filter settings


### PR DESCRIPTION
See [ticket #32969](https://trac.torproject.org/projects/tor/ticket/32969).

I decided against the original proposed change since I realized that these scripts must set a value of `CHUTNEY_DATA_DIR` (and it must be an absolute path) and can't rely on chutney to choose one for them. This is because the `tools/warnings.sh` file needs to know the actual data directory used so that it can later set `DEST="$CHUTNEY_DATA_DIR/nodes"`.

Instead I made changes to explicitly allow absolute paths. Otherwise the code works exactly as it did before.

Original:

>When you set up a tor network with something like:
>
>```tools/test-network.sh --flavor basic --net-dir /tmp/chutney-net```
>
>the `tools/test-network.sh` script will set `$CHUTNEY_DATA_DIR` based on the value of `--net-dir` and then call `tools/bootstrap-network.sh`. This bootstrapping script will then overwrite the variable `$CHUTNEY_DATA_DIR` if that directory doesn't exist or if the path is relative. This causes unexpected behavior when the user explicitly sets the `--net-dir` option. For example, Chutney works fine if you provide it with a directory that doesn't exist (it will create that directory automatically), so there is no need for the `tools/bootstrap-network.sh` script to unexpectedly change it to `$CHUTNEY_PATH/net`. The `tools/bootstrap-network.sh` also does not need to change it to an absolute path since Chutney ​does this automatically.