### PR TITLE
Error message for missing tor uses correct env var names

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -167,10 +167,14 @@ def _warnMissingTor(tor_path, cmdline, tor_name="tor"):
     """Log a warning that the binary tor_name can't be found at tor_path
        while running cmdline.
     """
-    print(("Cannot find the {} binary at '{}' for the command line '{}'. " +
-           "Set the TOR_DIR environment variable to the directory " +
-           "containing {}.")
-          .format(tor_name, tor_path, " ".join(cmdline), tor_name))
+    help_msg_fmt = "Set the '{}' environment variable to the directory containing '{}'."
+    help_msg = ""
+    if tor_name == "tor":
+        help_msg = help_msg_fmt.format("CHUTNEY_TOR", tor_name)
+    elif tor_name == "tor-gencert":
+        help_msg = help_msg_fmt.format("CHUTNEY_TOR_GENCERT", tor_name)
+    print(("Cannot find the {} binary at '{}' for the command line '{}'. {}")
+          .format(tor_name, tor_path, " ".join(cmdline), help_msg))
 
 def run_tor(cmdline, exit_on_missing=True):
     """Run the tor command line cmdline, which must start with the path or


### PR DESCRIPTION
See [ticket #33041](https://trac.torproject.org/projects/tor/ticket/33041).

>When you attempt to run Chutney using a command like:
>
>```
>./chutney configure networks/basic
>```
>
>it will print the following error message if it cannot find `tor` or `tor-gencert`:
>
>```
>Cannot find the tor-gencert binary at 'tor-gencert' for the command
>line 'tor-gencert --create-identity-key --passphrase-fd 0 <snip>'.
>Set the TOR_DIR environment variable to the directory containing
>tor-gencert.
>```
>
>Chutney (the Python code) does not actually use this `TOR_DIR` environment variable (it's only used by `tools/test-network.sh` and related scripts). Instead the error message should say that the user should set the `CHUTNEY_TOR` and `CHUTNEY_TOR_GENCERT` environment variables.