### PR TITLE
Ticket 33304 - Return None for pid when pid file is empty

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -863,7 +863,10 @@ class LocalNodeController(NodeController):
             return None
 
         with open(pidfile, 'r') as f:
-            return int(f.read())
+            try:
+                return int(f.read())
+            except ValueError:
+                return None
 
     def isRunning(self, pid=None):
         """Return true iff this node is running.  (If 'pid' is provided, we


### PR DESCRIPTION
See ticket [#33304](https://trac.torproject.org/projects/tor/ticket/33304).

> In the `getPid()` function, Chutney reads the pid from a file and converts it to an integer.
> 
> ```
> if not os.path.exists(pidfile):
>     return None
> 
> with open(pidfile, 'r') as f:
>     return int(f.read())
> ```
> 
> This can result in the following error:
> 
> ```
> ValueError: invalid literal for int() with base 10: ''
> ```
