### PR TITLE
Function to make chutney check for relay microdescriptors before verifying 

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -31,6 +31,9 @@ import chutney.Templating
 import chutney.Traffic
 import chutney.Util
 
+# Keep in sync with torrc_templates/authority.i V3AuthVotingInterval
+V3_AUTH_VOTING_INTERVAL = 20.0
+
 _BASE_ENVIRON = None
 _TOR_VERSIONS = None
 _TORRC_OPTIONS = None
@@ -49,7 +52,6 @@ def getenv_type(env_var, default, type_, type_name=None):
     """
        Return the value of the environment variable 'envar' as type_,
        or 'default' if no such variable exists.
-
        Raise ValueError using type_name if the environment variable is set,
        but type_() raises a ValueError on its value. (If type_name is None
        or empty, the ValueError uses type_'s string representation instead.)
@@ -70,7 +72,6 @@ def getenv_int(env_var, default):
     """
        Return the value of the environment variable 'envar' as an int,
        or 'default' if no such variable exists.
-
        Raise ValueError if the environment variable is set, but is not an int.
     """
     return getenv_type(env_var, default, int, type_name='an int')
@@ -79,9 +80,7 @@ def getenv_bool(env_var, default):
     """
        Return the value of the environment variable 'envar' as a bool,
        or 'default' if no such variable exists.
-
        Unlike bool(), converts 0, "False", and "No" to False.
-
        Raise ValueError if the environment variable is set, but is not a bool.
     """
     try:
@@ -98,11 +97,9 @@ def getenv_bool(env_var, default):
 def mkdir_p(d, mode=448):
     """Create directory 'd' and all of its parents as needed.  Unlike
        os.makedirs, does not give an error if d already exists.
-
        448 is the decimal representation of the octal number 0700. Since
        python2 only supports 0700 and python3 only supports 0o700, we can use
        neither.
-
        Note that python2 and python3 differ in how they create the
        permissions for the intermediate directories.  In python3, 'mode'
        only sets the mode for the last directory created.
@@ -138,15 +135,12 @@ def get_absolute_net_path():
     """
        Returns the absolute path of the "net" directory that chutney should
        use to store "node*" directories containing torrcs and tor runtime data.
-
        If the CHUTNEY_DATA_DIR environmental variable is an absolute path, it
        is returned unmodified, regardless of whether the path actually exists.
        (Chutney creates any directories that do not exist.)
-
        Otherwise, if it is a relative path, and there is an existing directory
        with that name in the directory containing the chutney executable
        script, return that path (this check exists for legacy reasons).
-
        Finally, return the path relative to the current working directory,
        regardless of whether the path actually exists.
     """
@@ -173,7 +167,6 @@ def get_absolute_nodes_path():
        Returns the absolute path of the "nodes" symlink that points to the
        "nodes*" directory that chutney should use to store the current
        network's torrcs and tor runtime data.
-
        See get_new_absolute_nodes_path() for more details.
     """
     # there's no way to customise this: we really don't need more options
@@ -183,10 +176,8 @@ def get_new_absolute_nodes_path(now=time.time()):
     """
        Returns the absolute path of a unique "nodes*" directory that chutney
        should use to store the current network's torrcs and tor runtime data.
-
        The nodes directory suffix is based on the current timestamp,
        incremented if necessary to avoid collisions with existing directories.
-
        (The existing directory check contains known race conditions: running
        multiple simultaneous chutney instances on the same "net" directory is
        not supported. The uniqueness check is only designed to avoid
@@ -228,9 +219,7 @@ def _warnMissingTor(tor_path, cmdline, tor_name="tor"):
 def run_tor(cmdline, exit_on_missing=True):
     """Run the tor command line cmdline, which must start with the path or
        name of a tor binary.
-
        Returns the combined stdout and stderr of the process.
-
        If exit_on_missing is true, warn and exit if the tor binary is missing.
        Otherwise, raise a MissingBinaryException.
     """
@@ -268,7 +257,6 @@ def launch_process(cmdline, tor_name="tor", stdin=None, exit_on_missing=True):
     """Launch the command line cmdline, which must start with the path or
        name of a binary. Use tor_name as the canonical name of the binary in
        logs. Pass stdin to the Popen constructor.
-
        Returns the Popen object for the launched process.
     """
     if tor_name == "tor":
@@ -302,7 +290,6 @@ def run_tor_gencert(cmdline, passphrase):
     """Run the tor-gencert command line cmdline, which must start with the
        path or name of a tor-gencert binary.
        Then send passphrase to the stdin of the process.
-
        Returns the combined stdout and stderr of the process.
     """
     p = launch_process(cmdline,
@@ -373,7 +360,6 @@ def get_tor_modules(tor):
     """Check the list of compile-time modules advertised by the given
        'tor' binary, and return a map from module name to a boolean
        describing whether it is supported.
-
        Unlisted modules are ones that Tor did not treat as compile-time
        optional modules.
     """
@@ -407,7 +393,6 @@ class Node(object):
 
     """A Node represents a Tor node or a set of Tor nodes.  It's created
        in a network configuration file.
-
        This class is responsible for holding the user's selected node
        configuration, and figuring out how the node needs to be
        configured and launched.
@@ -700,7 +685,6 @@ class LocalNodeBuilder(NodeBuilder):
 
     def _makeHiddenServiceDir(self):
         """Create the hidden service subdirectory for this node.
-
           The directory name is stored under the 'hs_directory' environment
           key. It is combined with the 'dir' data directory key to yield the
           path to the hidden service directory.
@@ -760,6 +744,18 @@ class LocalNodeBuilder(NodeBuilder):
                   .format(" ".join(cmdline), stdouterr))
             sys.exit(1)
         self._env['fingerprint'] = fingerprint
+
+
+    def _setEd25519Id(self):
+      """Make chutney check for relay microdescriptors before verifying"""
+        datadir = self._env['dir']
+        key_directory =  os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
+        with open( key_directory , 'rb') as f:
+            f.seek(32)
+            rest_file = f.read()
+            EncodedValue = base64.b64encode(rest_file)
+            ed25519_id = str(EncodedValue)[2:-2]
+            self._env['ed25519-id'] = ed25519_id
 
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
@@ -903,6 +899,60 @@ class LocalNodeController(NodeController):
            True for authorities and relays; False for bridges and clients.
         """
         return self.getDirServer() and not self.getBridge()
+
+    def getOnionService(self):
+        """Is this node an onion service?"""
+        if self._env['tag'].startswith('h'):
+            return 1
+
+        try:
+            return self._env['hs']
+        except KeyError:
+            return 0
+
+    # Older tor versions are slow to download microdescs
+    # This version prefix compares less than all 0.4-series, and any
+    # future version series (for example, 0.5, 1.0, and 22.0)
+    MIN_TOR_VERSION_FOR_MICRODESC_FIX = 'Tor 0.4'
+
+    MIN_TIME_FOR_COMPLETE_CONSENSUS = V3_AUTH_VOTING_INTERVAL*1.5
+    MIN_START_TIME_LEGACY = MIN_TIME_FOR_COMPLETE_CONSENSUS + 20
+    MIN_START_TIME_RECENT = 0
+
+    def getMinStartTime(self):
+        """Returns the minimum start time before verifying, regardless of
+           whether the network has bootstrapped, or the dir info has been
+           distributed.
+           Based on $CHUTNEY_EXTRA_START_TIME and the tor version.
+        """
+        # User overrode the dynamic time
+        env_min_time = getenv_int('CHUTNEY_MIN_START_TIME', None)
+        if env_min_time is not None:
+            return env_min_time
+
+        tor = self._env['tor']
+        tor_version = get_tor_version(tor)
+        min_version = LocalNodeController.MIN_TOR_VERSION_FOR_MICRODESC_FIX
+
+        # We could compare the version components, but this works for now
+        # If it's not our Tor, expect it to behave better
+        if tor_version.startswith('Tor ') and tor_version < min_version:
+            return LocalNodeController.MIN_START_TIME_LEGACY
+        else:
+            return LocalNodeController.MIN_START_TIME_RECENT
+
+    NODE_WAIT_FOR_UNCHECKED_DIR_INFO = 10
+    HS_WAIT_FOR_UNCHECKED_DIR_INFO = V3_AUTH_VOTING_INTERVAL + 10
+
+    def getUncheckedDirInfoWaitTime(self):
+        """Returns the amount of time to wait before verifying, after the
+           network has bootstrapped, and the dir info has been distributed.
+           Based on whether this node is an onion service.
+        """
+        if self.getOnionService():
+            return LocalNodeController.HS_WAIT_FOR_UNCHECKED_DIR_INFO
+        else:
+            return LocalNodeController.NODE_WAIT_FOR_UNCHECKED_DIR_INFO
 
     def getPid(self):
         """Assuming that this node has its pidfile in ${dir}/pid, return
@@ -1142,17 +1192,14 @@ class LocalNodeController(NodeController):
              * a boolean indicating whether this node is a bridge client, and
              * a dict with the expected paths to the consensus files for this
                node.
-
            If v2_dir_paths is True, returns the v3 directory paths.
            Otherwise, returns the bridge status path.
            If v2_dir_paths is True, but this node is not a bridge client or
            bridge authority, returns None. (There are no paths.)
-
            Directory servers usually have both consensus flavours.
            Clients usually have the microdesc consensus, but they may have
            either flavour. (Or both flavours.)
            Only the bridge authority has the bridge networkstatus.
-
            The dict keys are:
              * "ns_cons", "desc", and "desc_new";
              * "md_cons", "md", and "md_new"; and
@@ -1205,9 +1252,7 @@ class LocalNodeController(NodeController):
     def getNodePublishedDirInfoPaths(self):
         """Return a dict of paths to consensus files, where we expect this
            node to be published.
-
            The dict keys are the nicks for each node.
-
            See getNodeCacheDirInfoPaths() for the path data structure, and which
            nodes appear in each type of directory.
         """
@@ -1236,7 +1281,6 @@ class LocalNodeController(NodeController):
     def getNodeDirInfoStatusPattern(self, dir_format):
         """Returns a regular expression pattern for finding this node's entry
            in a dir_format file.
-
            The microdesc format is not yet implemented, because it requires
            the ed25519 key. (Or RSA block matching, which is hard.)
         """
@@ -1273,7 +1317,6 @@ class LocalNodeController(NodeController):
     def getFileDirInfoStatus(self, dir_format, dir_path):
         """Check dir_path, a directory path used by another node, to see if
            this node is present. The directory path is a dir_format file.
-
            Returns a status 3-tuple containing:
              * an integer status code:
                * negative numbers correspond to errors,
@@ -1319,15 +1362,11 @@ class LocalNodeController(NodeController):
         """Combine the directory statuses in dir_status, if their keys
            appear in status_key_list. Keys may be directory formats, or
            node nicks.
-
            If best is True, choose the best status, otherwise, choose the
            worst status.
-
            If ignore_missing is True, ignore missing statuses, if there is any
            other status available.
-
            If statuses are equal, combine their format sets.
-
            Returns None if the status list is empty.
         """
         dir_status_list = [ dir_status[status_key]
@@ -1376,24 +1415,19 @@ class LocalNodeController(NodeController):
                                     to_bridge_client):
         """Summarise the statuses for this node, among all the files used by
            the other node.
-
            to_dir_server is True if the other node is a directory server.
            to_bridge_client is True if the other node is a bridge client.
-
            Combine these alternate files by choosing the best status:
              * desc_alts: "desc" and "desc_new"
              * md_alts: "md" and "md_new"
-
            Handle these alternate formats by ignoring missing directory files,
            then choosing the worst status:
              * cons_all: "ns_cons" and "md_cons"
              * desc_all: "desc"/"desc_new" and
                           "md"/"md_new"
-
            Add an "node_dir" status that describes the overall status, which
            is the worst status among descriptors, consensuses, and the bridge
            networkstatus (if relevant). Return this status.
-
            Returns None if no status is expected.
         """
         from_bridge = self.getBridge()
@@ -1492,13 +1526,10 @@ class LocalNodeController(NodeController):
                                   to_bridge_client):
         """Check all the directory paths used by another node, to see if this
            node is present.
-
            to_dir_server is True if the other node is a directory server.
            to_bridge_client is True if the other node is a bridge client.
-
            Returns a dict containing a status 3-tuple for every relevant
            directory format. See getFileDirInfoStatus() for more details.
-
            Returns None if the node doesn't have any directory files
            containing published information from this node.
         """
@@ -1527,7 +1558,6 @@ class LocalNodeController(NodeController):
     def getNodeDirInfoStatusList(self):
         """Look through the directories on each node, and work out if
            this node is in that directory.
-
            Returns a dict containing a status 3-tuple for each relevant node.
            The 3-tuple contains:
              * a status code,
@@ -1535,14 +1565,11 @@ class LocalNodeController(NodeController):
              * a status message string.
            See getNodeCacheDirInfoStatus() and getFileDirInfoStatus() for
            more details.
-
            If this node is a directory authority, bridge authority, or relay
            (including exits), checks v3 directory consensuses, descriptors,
            microdesc consensuses, and microdescriptors.
-
            If this node is a bridge, checks bridge networkstatuses, and
            descriptors on bridge authorities and bridge clients.
-
            If this node is a client (including onion services), returns None.
         """
         dir_files = self.getNodePublishedDirInfoPaths()
@@ -1580,7 +1607,6 @@ class LocalNodeController(NodeController):
     def summariseNodeDirInfoStatus(self, dir_status):
         """Summarise the statuses for this node's descriptor, among all the
            directory files used by all other nodes.
-
            Returns a dict containing a status 4-tuple for each status code.
            The 4-tuple contains:
              * a status code,
@@ -1590,11 +1616,9 @@ class LocalNodeController(NodeController):
              * a status message string.
            See getNodeCacheDirInfoStatus() and getFileDirInfoStatus() for
            more details.
-
            Also add an "node_all" status that describes the overall status,
            which is the worst status among all the other nodes' directory
            files.
-
            Returns None if no status is expected.
         """
         node_status = dict()
@@ -1661,7 +1685,6 @@ class LocalNodeController(NodeController):
     def getNodeDirInfoStatus(self):
         """Return a 4-tuple describing the status of this node's descriptor,
            in all the directory documents across the network.
-
            If this node does not have a descriptor, returns None.
         """
         dir_status = self.getNodeDirInfoStatusList()
@@ -1683,7 +1706,6 @@ class LocalNodeController(NodeController):
     def isInExpectedDirInfoDocs(self):
         """Return True if the descriptors for this node are in all expected
            directory documents.
-
            Return None if this node does not publish descriptors.
         """
         node_status = self.getNodeDirInfoStatus()
@@ -1776,9 +1798,7 @@ class TorEnviron(chutney.Templating.Environ):
 
     """Subclass of chutney.Templating.Environ to implement commonly-used
        substitutions.
-
        Environment fields provided:
-
           orport, controlport, socksport, dirport: *Port torrc option
           dir: DataDirectory torrc option
           nick: Nickname torrc option
@@ -1797,7 +1817,6 @@ class TorEnviron(chutney.Templating.Environ):
              Chutney users can disable the sandbox using:
                 export CHUTNEY_TOR_SANDBOX=0
              if it doesn't work on their version of glibc.
-
        Environment fields used:
           nodenum: chutney's internal node number for the node
           tag: a short text string that represents the type of node
@@ -2092,6 +2111,7 @@ class Network(object):
                                most_recent_desc_status,
                                elapsed=None,
                                msg="Bootstrap in progress"):
+        nick_set = set()
         cons_auth_nick_set = set()
         elapsed_msg = ""
         if elapsed:
@@ -2103,6 +2123,7 @@ class Network(object):
         for c, boot_status in zip(controllers, most_recent_bootstrap_status):
             c.check(listRunning=False, listNonRunning=True)
             nick = c.getNick()
+            nick_set.add(nick)
             if c.getConsensusAuthority():
                 cons_auth_nick_set.add(nick)
             pct, kwd, bmsg = boot_status
@@ -2113,15 +2134,19 @@ class Network(object):
                                                   pct,
                                                   kwd,
                                                   bmsg))
+        cache_client_nick_set = nick_set.difference(cons_auth_nick_set)
         print("Published dir info:")
         for c in controllers:
             nick = c.getNick()
             if nick in most_recent_desc_status:
                 desc_status = most_recent_desc_status[nick]
                 code, nodes, docs, dmsg = desc_status
-                if len(nodes) == len(self._nodes):
+                node_set = set(nodes)
+                if node_set == nick_set:
                     nodes = "all nodes"
-                elif len(cons_auth_nick_set.intersection(nodes)) == 0:
+                elif node_set == cons_auth_nick_set:
+                    nodes = "dir auths"
+                elif node_set == cache_client_nick_set:
                     nodes = "caches and clients"
                 else:
                     nodes = [ node.replace("test", "")
@@ -2145,19 +2170,24 @@ class Network(object):
                                                              dmsg))
         print()
 
-    # Keep in sync with torrc_templates/authority.i V3AuthVotingInterval
-    V3_AUTH_VOTING_INTERVAL = 20.0
-
     CHECK_NETWORK_STATUS_DELAY = 1.0
     PRINT_NETWORK_STATUS_DELAY = V3_AUTH_VOTING_INTERVAL/2.0
-    WAIT_FOR_UNCHECKED_DIR_INFO_DELAY = V3_AUTH_VOTING_INTERVAL + 1.0
+    CHECKS_PER_PRINT = PRINT_NETWORK_STATUS_DELAY / CHECK_NETWORK_STATUS_DELAY
 
     def wait_for_bootstrap(self):
         print("Waiting for nodes to bootstrap...\n")
         start = time.time()
         limit = start + getenv_int("CHUTNEY_START_TIME", 60)
         next_print_status = start + Network.PRINT_NETWORK_STATUS_DELAY
+
         controllers = [n.getController() for n in self._nodes]
+        min_time_list = [c.getMinStartTime() for c in controllers]
+        min_time = max(min_time_list)
+        wait_time_list = [c.getUncheckedDirInfoWaitTime() for c in controllers]
+        wait_time = max(wait_time_list)
+
+        checks_since_last_print = 0
+
         most_recent_bootstrap_status = [ None ] * len(controllers)
         most_recent_desc_status = dict()
         while True:
@@ -2192,7 +2222,16 @@ class Network(object):
                                             most_recent_desc_status,
                                             elapsed=elapsed,
                                             msg="Bootstrap finished")
-                # Avoid a race condition where:
+
+                # Wait for unchecked dir info (see #33595)
+                print("Waiting {} seconds for other dir info to sync...\n"
+                      .format(int(wait_time)))
+                time.sleep(wait_time)
+                now = time.time()
+                elapsed = now - start
+
+                # Wait for a minimum amount of run time, to avoid a race
+                # condition where:
                 #  - all the directory info that chutney checks is present,
                 #  - but some unchecked dir info is missing
                 #    (perhaps microdescriptors, see #33428)
@@ -2203,19 +2242,58 @@ class Network(object):
                 # We have only seen this race condition in 0.3.5. The fixes to
                 # microdescriptor downloads in 0.4.0 or 0.4.1 likely resolve
                 # this issue.
-                print("Waiting {} seconds for other dir info to sync...\n"
-                      .format(int(Network.WAIT_FOR_UNCHECKED_DIR_INFO_DELAY)))
-                time.sleep(Network.WAIT_FOR_UNCHECKED_DIR_INFO_DELAY)
+                if elapsed < min_time:
+                    sleep_time = min_time - elapsed
+                    print(("Waiting another {} seconds for legacy tor "
+                           "microdesc downloads...\n")
+                          .format(int(sleep_time)))
+                    time.sleep(sleep_time)
+                    now = time.time()
+                    elapsed = now - start
                 return True
             if now >= limit:
                 break
             if now >= next_print_status:
+                if checks_since_last_print <= Network.CHECKS_PER_PRINT/2:
+                    self.print_bootstrap_status(controllers,
+                                                most_recent_bootstrap_status,
+                                                most_recent_desc_status,
+                                                elapsed=elapsed,
+                                                msg="Internal timing error")
+                    print("checks_since_last_print: {} (expected: {})"
+                          .format(checks_since_last_print,
+                                  Network.CHECKS_PER_PRINT))
+                    print("start: {} limit: {}".format(start, limit))
+                    print("next_print_status: {} now: {}"
+                          .format(next_print_status, time.time()))
+                    return False
+                else:
+                    self.print_bootstrap_status(controllers,
+                                                most_recent_bootstrap_status,
+                                                most_recent_desc_status,
+                                                elapsed=elapsed)
+                    next_print_status = (now +
+                                         Network.PRINT_NETWORK_STATUS_DELAY)
+                    checks_since_last_print = 0
+
+            time.sleep(Network.CHECK_NETWORK_STATUS_DELAY)
+
+            # macOS Travis has some weird hangs, make sure we're not hanging
+            # in this loop due to clock skew
+            checks_since_last_print += 1
+            if checks_since_last_print >= Network.CHECKS_PER_PRINT*2:
                 self.print_bootstrap_status(controllers,
                                             most_recent_bootstrap_status,
                                             most_recent_desc_status,
-                                            elapsed=elapsed)
-                next_print_status = now + Network.PRINT_NETWORK_STATUS_DELAY
-            time.sleep(Network.CHECK_NETWORK_STATUS_DELAY)
+                                            elapsed=elapsed,
+                                            msg="Internal timing error")
+                print("checks_since_last_print: {} (expected: {})"
+                      .format(checks_since_last_print,
+                              Network.CHECKS_PER_PRINT))
+                print("start: {} limit: {}".format(start, limit))
+                print("next_print_status: {} now: {}"
+                      .format(next_print_status, time.time()))
+                return False
 
         self.print_bootstrap_status(controllers,
                                     most_recent_bootstrap_status,


### PR DESCRIPTION
Wrote a function that follows the following the steps to verify the microdescriptors :-
- read keys/ed25519_master_id_public_key from datadir, if that file exists
- extract the key data
- convert it to base64
- discard the trailing "="
- set ed25519-id in the Environ to that value

hopefully  closes #Ticket33428 https://trac.torproject.org/projects/tor/ticket/33428