### PR TITLE
Ticket 33428: Read relay ed25519 identity keys

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -668,8 +668,10 @@ class LocalNodeBuilder(NodeBuilder):
             self._genAuthorityKey()
         if self._env['relay']:
             self._genRouterKey()
+            self._setEd25519Id()
         if self._env['hs']:
             self._makeHiddenServiceDir()
+            
 
     def config(self, net):
         """Called to configure a node: creates a torrc file for it."""
@@ -771,7 +773,7 @@ class LocalNodeBuilder(NodeBuilder):
         datadir = self._env['dir']
         key_directory = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
         if os.path.exists(key_directory):
-            raise ValueError("File does not exit.")
+            raise ValueError("File does not exit")
         elif os.stat(key_directory).st_size == 0:
             raise ValueError("File is empty")
         else:

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -672,7 +672,6 @@ class LocalNodeBuilder(NodeBuilder):
         if self._env['hs']:
             self._makeHiddenServiceDir()
             
-
     def config(self, net):
         """Called to configure a node: creates a torrc file for it."""
         self._createTorrcFile()
@@ -767,32 +766,30 @@ class LocalNodeBuilder(NodeBuilder):
             sys.exit(1)
         self._env['fingerprint'] = fingerprint
        
-
     def _setEd25519Id(self):
         """Read the ed25519 identity key for this router, and set up the 'ed25519-id' entry in the Environ"""
         datadir = self._env['dir']
         key_directory = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
         EXPECTED_ED25519_FILE_SIZE = 64
         CURRENT_FILE_SIZE = os.stat(key_directory).st_size
-        if os.path.exists(key_directory) == False:
+        if not os.path.exists(key_directory):
             raise ValueError("File does not exist")
         elif CURRENT_FILE_SIZE != EXPECTED_ED25519_FILE_SIZE:
-            raise ValueError("The current size of the file is {} bytes, which is not matching the expected value of {} bytes".format(CURRENT_FILE_SIZE,EXPECTED_ED25519_FILE_SIZE))
+            raise ValueError("The current size of the file is {} bytes, which is not matching the expected value of {} bytes".format(CURRENT_FILE_SIZE, EXPECTED_ED25519_FILE_SIZE))
         else:
             with open(key_directory, 'rb') as f:
                 ED25519_KEY_POSITION = 32
                 f.seek(ED25519_KEY_POSITION)
                 rest_file = f.read()
-                EncodedValue = base64.b64encode(rest_file)
-                ed25519_id = EncodedValue.decode('utf-8').replace('=', '')
+                encoded_value = base64.b64encode(rest_file)
+                ed25519_id = encoded_value.decode('utf-8').replace('=', '')
                 EXPECTED_ED25519_BASE64_KEY_SIZE = 43
                 CURRENT_ED25519_BASE64_KEY_SIZE = len(ed25519_id)
                 if CURRENT_ED25519_BASE64_KEY_SIZE != EXPECTED_ED25519_BASE64_KEY_SIZE:
-                    raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE,EXPECTED_ED25519_BASE64_KEY_SIZE))
+                    raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE, EXPECTED_ED25519_BASE64_KEY_SIZE))
                 else:
                     self._env['ed25519-id'] = ed25519_id
             
-
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
         and AlternateBridgeAuthority lines for

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -769,15 +769,16 @@ class LocalNodeBuilder(NodeBuilder):
     def _setEd25519Id(self):
         """Read the ed25519 identity key for this router, and set up the 'ed25519-id' entry in the Environ"""
         datadir = self._env['dir']
-        key_directory = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
+        key_file = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
         EXPECTED_ED25519_FILE_SIZE = 64
-        CURRENT_FILE_SIZE = os.stat(key_directory).st_size
-        if not os.path.exists(key_directory):
-            raise ValueError("File does not exist")
+        CURRENT_FILE_SIZE = os.stat(key_file).st_size
+        if not os.path.exists(key_file):
+            print("File {} does not exist. Are you running a very old tor version?".format(key_file))
+            return
         elif CURRENT_FILE_SIZE != EXPECTED_ED25519_FILE_SIZE:
             raise ValueError("The current size of the file is {} bytes, which is not matching the expected value of {} bytes".format(CURRENT_FILE_SIZE, EXPECTED_ED25519_FILE_SIZE))
         else:
-            with open(key_directory, 'rb') as f:
+            with open(key_file, 'rb') as f:
                 ED25519_KEY_POSITION = 32
                 f.seek(ED25519_KEY_POSITION)
                 rest_file = f.read()

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -764,6 +764,19 @@ class LocalNodeBuilder(NodeBuilder):
             sys.exit(1)
         self._env['fingerprint'] = fingerprint
 
+
+    def _setEd25519Id(self):
+        """Make chutney check for relay microdescriptors before verifying"""
+        datadir = self._env['dir']
+        key_directory =  os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
+        with open(key_directory ,'rb') as f:
+            f.seek(32)
+            rest_file = f.read()
+            EncodedValue = base64.b64encode(rest_file)
+            ed25519_id = str(EncodedValue)[2:-2]
+            self._env['ed25519-id'] = ed25519_id
+      
+
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
         and AlternateBridgeAuthority lines for

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -772,10 +772,12 @@ class LocalNodeBuilder(NodeBuilder):
         """Read the ed25519 identity key for this router, and set up the 'ed25519-id' entry in the Environ"""
         datadir = self._env['dir']
         key_directory = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
-        if os.path.exists(key_directory):
-            raise ValueError("File does not exit")
-        elif os.stat(key_directory).st_size == 0:
-            raise ValueError("File is empty")
+        EXPECTED_ED25519_FILE_SIZE = 64
+        CURRENT_FILE_SIZE = os.stat(key_directory).st_size
+        if os.path.exists(key_directory) == False:
+            raise ValueError("File does not exist")
+        elif CURRENT_FILE_SIZE != EXPECTED_ED25519_FILE_SIZE:
+            raise ValueError("The current size of the file is {} bytes, which is not matching the expected value of {} bytes".format(CURRENT_FILE_SIZE,EXPECTED_ED25519_FILE_SIZE))
         else:
             with open(key_directory, 'rb') as f:
                 ED25519_KEY_POSITION = 32
@@ -783,8 +785,10 @@ class LocalNodeBuilder(NodeBuilder):
                 rest_file = f.read()
                 EncodedValue = base64.b64encode(rest_file)
                 ed25519_id = EncodedValue.decode('utf-8').replace('=', '')
-                if len(ed25519_id) != 43:
-                    raise ValueError("Length of key exceeding than correct value")
+                EXPECTED_ED25519_BASE64_KEY_SIZE = 43
+                CURRENT_ED25519_BASE64_KEY_SIZE = len(ed25519_id)
+                if CURRENT_ED25519_BASE64_KEY_SIZE != EXPECTED_ED25519_BASE64_KEY_SIZE:
+                    raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE,EXPECTED_ED25519_BASE64_KEY_SIZE))
                 else:
                     self._env['ed25519-id'] = ed25519_id
             


### PR DESCRIPTION
Followed the following points to build a function to check for relay microdescriptors before verification -
1. read keys/ed25519_master_id_public_key from datadir, if that file exists
2. extract the key data
3. convert it to base64
4. discard the trailing "="
5. set ed25519-id in the Environ to that value

Hopefully Close  https://trac.torproject.org/projects/tor/ticket/33428#comment:15