### PR TITLE
Ticket 33675: Adding regex to search microdescriptor files for relay ed25519 keys

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -957,7 +957,7 @@ class LocalNodeController(NodeController):
     MIN_TOR_VERSION_FOR_MICRODESC_FIX = 'Tor 0.4'
 
     MIN_TIME_FOR_COMPLETE_CONSENSUS = V3_AUTH_VOTING_INTERVAL*1.5
-    MIN_START_TIME_LEGACY = 0
+    MIN_START_TIME_LEGACY = MIN_TIME_FOR_COMPLETE_CONSENSUS + 20
     MIN_START_TIME_RECENT = 0
 
     def getMinStartTime(self):
@@ -983,7 +983,7 @@ class LocalNodeController(NodeController):
         else:
             return LocalNodeController.MIN_START_TIME_RECENT
 
-    NODE_WAIT_FOR_UNCHECKED_DIR_INFO = 0
+    NODE_WAIT_FOR_UNCHECKED_DIR_INFO = 10
     HS_WAIT_FOR_UNCHECKED_DIR_INFO = V3_AUTH_VOTING_INTERVAL + 10
 
     def getUncheckedDirInfoWaitTime(self):
@@ -1328,7 +1328,7 @@ class LocalNodeController(NodeController):
 
     def getNodeDirInfoStatusPattern(self, dir_format):
         """Returns a regular expression pattern for finding this node's entry
-           in a dir_format file and returning None if nickname or ed25519_key not found.
+           in a dir_format file and returning None if nickname or ed25519_id key not found.
         """
         nickname = self.getNick()
         ed25519_key = self.getEd25519Id()

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -789,7 +789,7 @@ class LocalNodeBuilder(NodeBuilder):
                 if CURRENT_ED25519_BASE64_KEY_SIZE != EXPECTED_ED25519_BASE64_KEY_SIZE:
                     raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE, EXPECTED_ED25519_BASE64_KEY_SIZE))
                 else:
-                    self._env['ed25519_id'] = ed25519_id
+                    ed25519_id = self._env['ed25519_id']
     
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
@@ -1327,8 +1327,12 @@ class LocalNodeController(NodeController):
            the ed25519 key. (Or RSA block matching, which is hard.)
         """
         nickname = self.getNick()
-        #ed25519_id = self._setEd25519Id()
-
+        ed25519_id = None
+        # old tor versions do not have an ed25519-id
+        if 'ed25519_id' in self._env:
+            ed25519_id = self._env['ed25519_id']
+         # old tor versions do not have an ed25519-id
+        
         cons = dir_format in ["ns_cons",
                               "md_cons",
                               "br_status"]

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1335,13 +1335,7 @@ class LocalNodeController(NodeController):
         """
         nickname = self.getNick()
         ed25519_key = self.getEd25519Id()
-         #old tor versions do not have an ed25519-id
-        #ed25519_id = None
-        #if 'ed25519_id' in self._env:
-             
-            #ed25519_id = self._env['ed25519_id']
          
-        
         cons = dir_format in ["ns_cons",
                               "md_cons",
                               "br_status"]
@@ -1364,12 +1358,12 @@ class LocalNodeController(NodeController):
         elif desc:
             return r'^router ' + nickname + " "
         elif md:
-            
+            if ed25519_key:
             # Not yet implemented, see #33428
-            return r'^id ed25519 ' + re.escape(ed25519_key)
-            # needs ed25519-identity from #30642
-            # or the existing keys/ed25519_master_id_public_key
-            
+                return r'^id ed25519 ' + re.escape(ed25519_key)
+            else:
+                return None
+            # Return None if ed25519_id not found
 
     def getFileDirInfoStatus(self, dir_format, dir_path):
         """Check dir_path, a directory path used by another node, to see if

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import time
+import base64
 
 from chutney.Debug import debug_flag, debug
 
@@ -667,6 +668,7 @@ class LocalNodeBuilder(NodeBuilder):
             self._genAuthorityKey()
         if self._env['relay']:
             self._genRouterKey()
+            self._setEd25519Id()
         if self._env['hs']:
             self._makeHiddenServiceDir()
 
@@ -763,7 +765,32 @@ class LocalNodeBuilder(NodeBuilder):
                   .format(" ".join(cmdline), stdouterr))
             sys.exit(1)
         self._env['fingerprint'] = fingerprint
-
+        
+    def _setEd25519Id(self):
+        """Read the ed25519 identity key for this router, and set up the 'ed25519-id' entry in the Environ"""
+        datadir = self._env['dir']
+        key_file = os.path.join(datadir, 'keys', "ed25519_master_id_public_key")
+        EXPECTED_ED25519_FILE_SIZE = 64
+        CURRENT_FILE_SIZE = os.stat(key_file).st_size
+        if not os.path.exists(key_file):
+            print("File {} does not exist. Are you running a very old tor version?".format(key_file))
+            return
+        elif CURRENT_FILE_SIZE != EXPECTED_ED25519_FILE_SIZE:
+            raise ValueError("The current size of the file is {} bytes, which is not matching the expected value of {} bytes".format(CURRENT_FILE_SIZE, EXPECTED_ED25519_FILE_SIZE))
+        else:
+            with open(key_file, 'rb') as f:
+                ED25519_KEY_POSITION = 32
+                f.seek(ED25519_KEY_POSITION)
+                rest_file = f.read()
+                encoded_value = base64.b64encode(rest_file)
+                ed25519_id = encoded_value.decode('utf-8').replace('=', '')
+                EXPECTED_ED25519_BASE64_KEY_SIZE = 43
+                CURRENT_ED25519_BASE64_KEY_SIZE = len(ed25519_id)
+                if CURRENT_ED25519_BASE64_KEY_SIZE != EXPECTED_ED25519_BASE64_KEY_SIZE:
+                    raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE, EXPECTED_ED25519_BASE64_KEY_SIZE))
+                else:
+                    self._env['ed25519_id'] = ed25519_id
+    
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
         and AlternateBridgeAuthority lines for
@@ -1300,6 +1327,7 @@ class LocalNodeController(NodeController):
            the ed25519 key. (Or RSA block matching, which is hard.)
         """
         nickname = self.getNick()
+        #ed25519_id = self._setEd25519Id()
 
         cons = dir_format in ["ns_cons",
                               "md_cons",
@@ -1324,10 +1352,10 @@ class LocalNodeController(NodeController):
             return r'^router ' + nickname + " "
         elif md:
             # Not yet implemented, see #33428
-            # r'^id ed25519 " + ed25519_identity (end of line)
+            return r'^id ed25519 ' + re.escape('ed25519_id')
             # needs ed25519-identity from #30642
             # or the existing keys/ed25519_master_id_public_key
-            return None
+            
 
     def getFileDirInfoStatus(self, dir_format, dir_path):
         """Check dir_path, a directory path used by another node, to see if

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -890,6 +890,13 @@ class LocalNodeController(NodeController):
         except KeyError:
             return 0
 
+    def getEd25519Id(self):
+        """Return the value of ed25519 key"""
+        try:
+            return self._env['ed25519_id']
+        except KeyError:
+            return None
+
     def getBridgeClient(self):
         """Return the bridge client flag for this node."""
         try:
@@ -1327,11 +1334,13 @@ class LocalNodeController(NodeController):
            the ed25519 key. (Or RSA block matching, which is hard.)
         """
         nickname = self.getNick()
-        ed25519_id = None
-        # old tor versions do not have an ed25519-id
-        if 'ed25519_id' in self._env:
-            ed25519_id = self._env['ed25519_id']
-         # old tor versions do not have an ed25519-id
+        ed25519_key = self.getEd25519Id()
+         #old tor versions do not have an ed25519-id
+        #ed25519_id = None
+        #if 'ed25519_id' in self._env:
+             
+            #ed25519_id = self._env['ed25519_id']
+         
         
         cons = dir_format in ["ns_cons",
                               "md_cons",
@@ -1355,8 +1364,9 @@ class LocalNodeController(NodeController):
         elif desc:
             return r'^router ' + nickname + " "
         elif md:
+            
             # Not yet implemented, see #33428
-            return r'^id ed25519 ' + re.escape('ed25519_id')
+            return r'^id ed25519 ' + re.escape(ed25519_key)
             # needs ed25519-identity from #30642
             # or the existing keys/ed25519_master_id_public_key
             

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1352,7 +1352,7 @@ class LocalNodeController(NodeController):
             return r'^router ' + nickname + " "
         elif md:
             # Not yet implemented, see #33428
-            return r'^id ed25519 ' + re.escape('ed25519_id')
+            return r'^id ed25519 ' + re.escape(ed25519_id)
             # needs ed25519-identity from #30642
             # or the existing keys/ed25519_master_id_public_key
             

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -957,7 +957,7 @@ class LocalNodeController(NodeController):
     MIN_TOR_VERSION_FOR_MICRODESC_FIX = 'Tor 0.4'
 
     MIN_TIME_FOR_COMPLETE_CONSENSUS = V3_AUTH_VOTING_INTERVAL*1.5
-    MIN_START_TIME_LEGACY = MIN_TIME_FOR_COMPLETE_CONSENSUS + 20
+    MIN_START_TIME_LEGACY = 0
     MIN_START_TIME_RECENT = 0
 
     def getMinStartTime(self):
@@ -983,7 +983,7 @@ class LocalNodeController(NodeController):
         else:
             return LocalNodeController.MIN_START_TIME_RECENT
 
-    NODE_WAIT_FOR_UNCHECKED_DIR_INFO = 10
+    NODE_WAIT_FOR_UNCHECKED_DIR_INFO = 0
     HS_WAIT_FOR_UNCHECKED_DIR_INFO = V3_AUTH_VOTING_INTERVAL + 10
 
     def getUncheckedDirInfoWaitTime(self):
@@ -1328,7 +1328,7 @@ class LocalNodeController(NodeController):
 
     def getNodeDirInfoStatusPattern(self, dir_format):
         """Returns a regular expression pattern for finding this node's entry
-           in a dir_format file and returning None if nickname or ed25519_id key not found.
+           in a dir_format file and returning None if nickname or ed25519_key not found.
         """
         nickname = self.getNick()
         ed25519_key = self.getEd25519Id()

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1328,10 +1328,7 @@ class LocalNodeController(NodeController):
 
     def getNodeDirInfoStatusPattern(self, dir_format):
         """Returns a regular expression pattern for finding this node's entry
-           in a dir_format file.
-
-           The microdesc format is not yet implemented, because it requires
-           the ed25519 key. (Or RSA block matching, which is hard.)
+           in a dir_format file and returning None if nickname or ed25519_id key not found.
         """
         nickname = self.getNick()
         ed25519_key = self.getEd25519Id()
@@ -1358,13 +1355,14 @@ class LocalNodeController(NodeController):
         elif desc:
             return r'^router ' + nickname + " "
         elif md:
+            print(nickname)
+            print(ed25519_key)
             if ed25519_key:
-            # Not yet implemented, see #33428
                 return r'^id ed25519 ' + re.escape(ed25519_key)
             else:
+                # If there is no ed25519_id, then we can't search for it
                 return None
-            # Return None if ed25519_id not found
-
+            
     def getFileDirInfoStatus(self, dir_format, dir_path):
         """Check dir_path, a directory path used by another node, to see if
            this node is present. The directory path is a dir_format file.

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -789,7 +789,7 @@ class LocalNodeBuilder(NodeBuilder):
                 if CURRENT_ED25519_BASE64_KEY_SIZE != EXPECTED_ED25519_BASE64_KEY_SIZE:
                     raise ValueError("The current length of the key is {}, which is not matching the expected length of {}".format(CURRENT_ED25519_BASE64_KEY_SIZE, EXPECTED_ED25519_BASE64_KEY_SIZE))
                 else:
-                    ed25519_id = self._env['ed25519_id']
+                    self._env['ed25519_id'] = ed25519_id
     
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,
@@ -1356,7 +1356,7 @@ class LocalNodeController(NodeController):
             return r'^router ' + nickname + " "
         elif md:
             # Not yet implemented, see #33428
-            return r'^id ed25519 ' + re.escape(ed25519_id)
+            return r'^id ed25519 ' + re.escape('ed25519_id')
             # needs ed25519-identity from #30642
             # or the existing keys/ed25519_master_id_public_key
             


### PR DESCRIPTION
@teor2345 : I have added the following code, however when I run the command "make test-network-all" generally the test fails and I get warning. I have tried to fix the errors by reading the log files and solved most of the syntactical errors. Also when I ran the command, when regex code was not added and only function _setEd25519() was present in the file, then all the test were successful. I did not got any error at all. It therefore seems error is in the new code for regex. I have attached the file below which has all the logs. Kindly help to solve the following error. Also made the new branch for testing because did not wanted to pollute the already working branch with errors, but have made the same changes regardless. Thank you for your help.
[single-onion-v23.log](https://github.com/torproject/chutney/files/4375999/single-onion-v23.log)
