### PR TITLE
Add bootstrap stage to check published onion descriptors for onion service nodes

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -851,6 +851,7 @@ class LocalNodeController(NodeController):
     def __init__(self, env):
         NodeController.__init__(self, env)
         self._env = env
+        self.most_recent_oniondesc_status = None
         self.most_recent_bootstrap_status = None
 
     def getNick(self):
@@ -1159,11 +1160,7 @@ class LocalNodeController(NodeController):
     HSV2_KEYWORD = "hidden service v2"
     HSV3_KEYWORD = "hidden service v3"
 
-    def getLastOnionServiceDescStatus(self):
-        """Look through info-level logs for onion service descriptor uploads
-           and return a 3-tuple of percentage complete, the hidden service
-           version, and message.
-        """
+    def updateLastOnionServiceDescStatus(self):
         logfname = self.getLogfile(info=True)
         if not os.path.exists(logfname):
             return (LocalNodeController.MISSING_FILE_CODE,
@@ -1188,7 +1185,14 @@ class LocalNodeController(NodeController):
                     keyword = LocalNodeController.HSV3_KEYWORD
                     message = m_v3.groups()[0]
                     break
-        return (percent, keyword, message)
+        self.most_recent_oniondesc_status = (percent, keyword, message)
+
+    def getLastOnionServiceDescStatus(self):
+        """Look through info-level logs for onion service descriptor uploads
+           and return a 3-tuple of percentage complete, the hidden service
+           version, and message.
+        """
+        return self.most_recent_oniondesc_status
 
     def updateLastBootstrapStatus(self):
         """Look through the logs and cache the last bootstrap message

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1214,12 +1214,11 @@ class LocalNodeController(NodeController):
         """Return true iff the logfile says that this instance is
            bootstrapped."""
         pct, _, _ = self.getLastBootstrapStatus()
-        if pct != LocalNodeController.SUCCESS_CODE:
-            return False
-        pct, _, _ = self.getLastOnionServiceDescStatus()
-        if pct != LocalNodeController.ONIONDESC_PUBLISHED_CODE:
-            return False
-        return True
+        if self.getOnionService():
+            return pct == LocalNodeController.SUCCESS_CODE
+        else:
+            pct, _, _ = self.getLastOnionServiceDescStatus()
+            return pct == LocalNodeController.ONIONDESC_PUBLISHED_CODE
 
     # There are 7 v3 directory document types, but some networks only use 6,
     # because they don't have a bridge authority

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1179,7 +1179,7 @@ class LocalNodeController(NodeController):
                     keyword = LocalNodeController.HSV2_KEYWORD
                     message = m_v2.groups()[0]
                     break
-                # else
+                # else check for HSv3
                 m_v3 = re.search(r'Service ([^\s]+ [^\s]+ descriptor of revision .*)',
                                  line)
                 if m_v3:

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -2266,8 +2266,6 @@ class Network(object):
 
         checks_since_last_print = 0
 
-        most_recent_bootstrap_status = [ None ] * len(controllers)
-        most_recent_desc_status = dict()
         while True:
             all_bootstrapped = True
             most_recent_bootstrap_status = [ ]

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1154,6 +1154,40 @@ class LocalNodeController(NodeController):
     SHORT_FILE_CODE = -100
     NO_PROGRESS_CODE = 0
     SUCCESS_CODE = 100
+    ONIONDESC_PUBLISHED_CODE = 200
+    HSV2_KEYWORD = "hidden service v2"
+    HSV3_KEYWORD = "hidden service v3"
+
+    def getLastOnionServiceDescStatus(self):
+        """Look through info-level logs for onion service descriptor uploads
+           and return a 3-tuple of percentage complete, the hidden service
+           version, and message.
+        """
+        logfname = self.getLogfile(info=True)
+        if not os.path.exists(logfname):
+            return (LocalNodeController.MISSING_FILE_CODE,
+                    "no_logfile", "There is no logfile yet.")
+        percent = LocalNodeController.NO_RECORDS_CODE
+        keyword = "no_message"
+        message = "No onion service descriptor messages yet."
+        with open(logfname, 'r') as f:
+            for line in f:
+                m_v2 = re.search(r'Launching upload for hidden service (.*)',
+                                 line)
+                if m_v2:
+                    percent = LocalNodeController.ONIONDESC_PUBLISHED_CODE
+                    keyword = LocalNodeController.HSV2_KEYWORD
+                    message = m_v2.groups()[0]
+                    break
+                # else
+                m_v3 = re.search(r'Service ([^\s]+ [^\s]+ descriptor of revision .*)',
+                                 line)
+                if m_v3:
+                    percent = LocalNodeController.ONIONDESC_PUBLISHED_CODE
+                    keyword = LocalNodeController.HSV3_KEYWORD
+                    message = m_v3.groups()[0]
+                    break
+        return (percent, keyword, message)
 
     def getLastBootstrapStatus(self):
         """Look through the logs and return the last bootstrap message

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1222,10 +1222,12 @@ class LocalNodeController(NodeController):
            bootstrapped."""
         pct, _, _ = self.getLastBootstrapStatus()
         if self.getOnionService():
-            return pct == LocalNodeController.SUCCESS_CODE
-        else:
+        if pct != LocalNodeController.SUCCESS_CODE:
+            return False
             pct, _, _ = self.getLastOnionServiceDescStatus()
-            return pct == LocalNodeController.ONIONDESC_PUBLISHED_CODE
+            if pct != LocalNodeController.ONIONDESC_PUBLISHED_CODE:
+                return False
+        return True
 
     # There are 7 v3 directory document types, but some networks only use 6,
     # because they don't have a bridge authority

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1221,6 +1221,13 @@ class LocalNodeController(NodeController):
         """
         return self.most_recent_bootstrap_status
 
+    def updateLastStatus(self):
+        """Update last messages this node has received, for use with
+           isBootstrapped and the getLast* functions.
+        """
+        self.updateLastOnionServiceDescStatus()
+        self.updateLastBootstrapStatus()
+
     def isBootstrapped(self):
         """Return true iff the logfile says that this instance is
            bootstrapped."""
@@ -2283,7 +2290,7 @@ class Network(object):
             most_recent_desc_status = dict()
             for c in controllers:
                 nick = c.getNick()
-                c.updateLastBootstrapStatus()
+                c.updateLastStatus()
 
                 if not c.isBootstrapped():
                     all_bootstrapped = False

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1161,6 +1161,9 @@ class LocalNodeController(NodeController):
     HSV3_KEYWORD = "hidden service v3"
 
     def updateLastOnionServiceDescStatus(self):
+        """Look through the logs and cache the last onion service
+           descriptor status received.
+        """
         logfname = self.getLogfile(info=True)
         if not os.path.exists(logfname):
             return (LocalNodeController.MISSING_FILE_CODE,
@@ -1188,9 +1191,9 @@ class LocalNodeController(NodeController):
         self.most_recent_oniondesc_status = (percent, keyword, message)
 
     def getLastOnionServiceDescStatus(self):
-        """Look through info-level logs for onion service descriptor uploads
-           and return a 3-tuple of percentage complete, the hidden service
-           version, and message.
+        """Return the last onion descriptor message fetched by
+           updateLastOnionServiceDescStatus as a 3-tuple of percentage
+           complete, the hidden service version, and message.
         """
         return self.most_recent_oniondesc_status
 

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1214,7 +1214,12 @@ class LocalNodeController(NodeController):
         """Return true iff the logfile says that this instance is
            bootstrapped."""
         pct, _, _ = self.getLastBootstrapStatus()
-        return pct == LocalNodeController.SUCCESS_CODE
+        if pct != LocalNodeController.SUCCESS_CODE:
+            return False
+        pct, _, _ = self.getLastOnionServiceDescStatus()
+        if pct != LocalNodeController.ONIONDESC_PUBLISHED_CODE:
+            return False
+        return True
 
     # There are 7 v3 directory document types, but some networks only use 6,
     # because they don't have a bridge authority

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -908,7 +908,7 @@ class LocalNodeController(NodeController):
         """
         return self.getDirServer() and not self.getBridge()
 
-    def getOnionService(self):
+    def isOnionService(self):
         """Is this node an onion service?"""
         if self._env['tag'].startswith('h'):
             return 1
@@ -959,7 +959,7 @@ class LocalNodeController(NodeController):
 
            Based on whether this node is an onion service.
         """
-        if self.getOnionService():
+        if self.isOnionService():
             return LocalNodeController.HS_WAIT_FOR_UNCHECKED_DIR_INFO
         else:
             return LocalNodeController.NODE_WAIT_FOR_UNCHECKED_DIR_INFO
@@ -1221,9 +1221,9 @@ class LocalNodeController(NodeController):
         """Return true iff the logfile says that this instance is
            bootstrapped."""
         pct, _, _ = self.getLastBootstrapStatus()
-        if self.getOnionService():
         if pct != LocalNodeController.SUCCESS_CODE:
             return False
+        if self.isOnionService():
             pct, _, _ = self.getLastOnionServiceDescStatus()
             if pct != LocalNodeController.ONIONDESC_PUBLISHED_CODE:
                 return False

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -1194,6 +1194,9 @@ class LocalNodeController(NodeController):
         """Return the last onion descriptor message fetched by
            updateLastOnionServiceDescStatus as a 3-tuple of percentage
            complete, the hidden service version, and message.
+
+           The return status depends on the last time updateLastStatus()
+           was called; that function must be called before this one.
         """
         return self.most_recent_oniondesc_status
 
@@ -1221,6 +1224,9 @@ class LocalNodeController(NodeController):
         """Return the last bootstrap message fetched by
            updateLastBootstrapStatus as a 3-tuple of percentage
            complete, keyword (optional), and message.
+
+           The return status depends on the last time updateLastStatus()
+           was called; that function must be called before this one.
         """
         return self.most_recent_bootstrap_status
 
@@ -1233,7 +1239,11 @@ class LocalNodeController(NodeController):
 
     def isBootstrapped(self):
         """Return true iff the logfile says that this instance is
-           bootstrapped."""
+           bootstrapped.
+
+           The return status depends on the last time updateLastStatus()
+           was called; that function must be called before this one.
+        """
         pct, _, _ = self.getLastBootstrapStatus()
         if pct != LocalNodeController.SUCCESS_CODE:
             return False


### PR DESCRIPTION
See [Tor Trac issue #33609](https://trac.torproject.org/projects/tor/ticket/33609) for details.

Add `getLastOnionServiceDescStatus()` in TorNet.py and modify `isBootstrapped()` to check if a node supplies an onion service, and if so, whether the onion descriptor has been published.