### PR TITLE
Add more documentation

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -520,22 +520,27 @@ class NodeBuilder(_NodeCommon):
     def checkConfig(self, net):
         """Try to format our torrc; raise an exception if we can't.
         """
+        raise NotImplementedError()
 
     def preConfig(self, net):
         """Called on all nodes before any nodes configure: generates keys as
            needed.
         """
+        raise NotImplementedError()
 
     def config(self, net):
         """Called to configure a node: creates a torrc file for it."""
+        raise NotImplementedError()
 
     def postConfig(self, net):
         """Called on each nodes after all nodes configure."""
+        raise NotImplementedError()
 
 
     def isSupported(self, net):
         """Return true if this node appears to have everything it needs;
            false otherwise."""
+        raise NotImplementedError()
 
 
 class NodeController(_NodeCommon):
@@ -558,9 +563,11 @@ class NodeController(_NodeCommon):
     def start(self):
         """Try to start this node; return True if we succeeded or it was
            already running, False if we failed."""
+        raise NotImplementedError()
 
     def stop(self, sig=signal.SIGINT):
         """Try to stop this node by sending it the signal 'sig'."""
+        raise NotImplementedError()
 
 
 class LocalNodeBuilder(NodeBuilder):

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -2112,6 +2112,9 @@ class Network(object):
             sys.exit(1)
 
     def configure(self):
+        """Invoked from command line: Configure and prepare the network to be
+           started.
+        """
         phase = self._dfltEnv['CUR_CONFIG_PHASE']
         if phase == 1:
             self.create_new_nodes_dir()
@@ -2152,7 +2155,9 @@ class Network(object):
         return n_ok == len(self._nodes)
 
     def restart(self):
-        """Stop and subsequently start our network's nodes."""
+        """Invoked from command line: Stop and subsequently start our
+           network's nodes.
+        """
         self.stop()
         self.start()
 
@@ -2247,6 +2252,9 @@ class Network(object):
     CHECKS_PER_PRINT = PRINT_NETWORK_STATUS_DELAY / CHECK_NETWORK_STATUS_DELAY
 
     def wait_for_bootstrap(self):
+        """Invoked from tools/test-network.sh to wait for the network to
+           bootstrap.
+        """
         print("Waiting for nodes to bootstrap...\n")
         start = time.time()
         limit = start + getenv_int("CHUTNEY_START_TIME", 60)

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -536,7 +536,6 @@ class NodeBuilder(_NodeCommon):
         """Called on each nodes after all nodes configure."""
         raise NotImplementedError()
 
-
     def isSupported(self, net):
         """Return true if this node appears to have everything it needs;
            false otherwise."""


### PR DESCRIPTION
Add/adjust docstrings, code commentary, and self-document code a bit better (raise `NotImplementedError` on functions that are expected to be overridden, for runtime feedback if the function is called, rather than silently passing).

I left `Node.specialize` uncommented because I have no clue what it does. Next step for me is to lint/analyze chutney codebase with a utility to check for dead codepaths, and maybe remove them if the code truly is dead and we don't want the functions. (There is at least one function already that's unused but we want to use it, so I'll be careful here.)