### PR TITLE
Fix undefined and unused names

### DIFF
--- a/lib/chutney/Templating.py
+++ b/lib/chutney/Templating.py
@@ -107,7 +107,7 @@ class _DictWrapper(object):
         self._parent = parent
 
     def _getitem(self, key, my):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __getitem__(self, key):
         return self.lookup(key, self)

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -19,7 +19,6 @@ import os
 import platform
 import re
 import signal
-import shutil
 import subprocess
 import sys
 import time
@@ -389,7 +388,7 @@ def get_tor_modules(tor):
         ]
     try:
         mods = run_tor(cmdline)
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         # Tor doesn't support --list-modules; act as if it said nothing.
         mods = ""
 

--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -67,7 +67,7 @@ def getenv_type(env_var, default, type_, type_name=None):
             type_name = str(type_)
         raise ValueError(("Invalid value for environment variable '{}': "
                           "expected {}, but got '{}'")
-                         .format(env_var, typename, strval))
+                         .format(env_var, type_name, strval))
 
 def getenv_int(env_var, default):
     """
@@ -1757,7 +1757,7 @@ class LocalNodeController(NodeController):
         node_status = self.getNodeDirInfoStatus()
         if node_status:
             status_code, _, _, _ = node_status
-            return status_code == LocalDirectoryController.SUCCESS_CODE
+            return status_code == LocalNodeController.SUCCESS_CODE
         else:
             # Clients don't publish descriptors, so they are always ok.
             # (But we shouldn't print a descriptor status for them.)
@@ -2020,7 +2020,7 @@ class Network(object):
     def _addRequirement(self, requirement):
         requirement = requirement.upper()
         if requirement not in KNOWN_REQUIREMENTS:
-            raise RuntimemeError(("Unrecognized requirement %r"%requirement))
+            raise RuntimeError(("Unrecognized requirement %r"%requirement))
         self._requirements.append(requirement)
 
     def move_aside_nodes_dir(self):

--- a/lib/chutney/Traffic.py
+++ b/lib/chutney/Traffic.py
@@ -28,9 +28,7 @@ from __future__ import unicode_literals
 import sys
 import socket
 import struct
-import errno
 import time
-import os
 
 import asyncore
 import asynchat


### PR DESCRIPTION
I ran flake8 on `lib/chutney/` and it found (among style suggestions, which I have ignored for now) both undefined and unused names. I removed unused modules and variables where it made sense, and I fixed instances of typographical errors and oversights.