### PR TITLE
Add basic arti support to chutney

### DIFF
--- a/lib/chutney/TorNet.py
+++ b/lib/chutney/TorNet.py
@@ -787,6 +787,8 @@ class LocalNodeBuilder(NodeBuilder):
         if os.path.exists(ed_fn):
             s = open(ed_fn).read().strip().split()[1]
             self._env['fingerprint_ed25519'] = s
+        else:
+            self._env['fingerprint_ed25519'] = ""
 
     def _getAltAuthLines(self, hasbridgeauth=False):
         """Return a combination of AlternateDirAuthority,


### PR DESCRIPTION
Each chutney network now generates an arti.toml file in its nodes
directory that can be used to connect to that network using arti.